### PR TITLE
Fixed in case when 'xesam:artist' key is missing

### DIFF
--- a/lyrics/player.py
+++ b/lyrics/player.py
@@ -97,8 +97,10 @@ class Player:
                 if title.strip() == '':
                     # if Title is empty, don't update
                     return False
-
-                artist = metadata['xesam:artist']
+                
+                artist=''
+                if 'xesam:artist' in metadata:
+                    artist = metadata['xesam:artist']
                 artist = artist[0] if isinstance(artist, list) else artist
 
                 if re.search('chromium|plasma', self.player_name) and '-' in title:


### PR DESCRIPTION
Now it should also work with YouTube downloaded files/ link playing in MPV when artist tags are missing in MPRIS. For me now also works with YT playing in Chrome, when earlier it wasn't.

This should fix issue #13 