### PR TITLE
removed deprecated module (dbus-python) and updated with working

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "Operating System :: POSIX :: Linux",
     ],
     install_requires=[
-        'dbus-python'
+        'dbus-next'
     ],
     python_requires='>=3.6',
     cmdclass={


### PR DESCRIPTION
#21 
Removed deprecated module -` dbus-python` and updated with equivalent working module `dbus-next` for Pypi install to work,