### PR TITLE
Fix issue: pass player name as an argument

### DIFF
--- a/lyrics/lyrics_in_terminal.py
+++ b/lyrics/lyrics_in_terminal.py
@@ -76,8 +76,8 @@ def main():
             print(track.get_text())
 
             exit(0)
-    else:
-        init_pager()
+        else:
+            init_pager()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Before the fix it was not possible for me to provide a playername in the console (as written in the usage https://github.com/Jugran/lyrics-in-terminal/wiki/Usage).

Steps to reproduce
1. `pip install lyrics-in-terminal==1.5.0`
1. Launch from terminal with a `playername` argument
```
$ lyrics {playername}
$ lyrics vlc
```
Expected: `lyrics` main screen opens
Observed: `lyrics` exits immediately