### PR TITLE
fix default lyrics command flow after #35

### DIFF
--- a/lyrics/lyrics_in_terminal.py
+++ b/lyrics/lyrics_in_terminal.py
@@ -47,7 +47,8 @@ def init_pager(stdscr):
 
     interval = defaults['interval']
     source = defaults['source']
-    mpd_connect = [defaults['mpd_host'], defaults['mpd_port'], defaults['mpd_pass']]
+    mpd_connect = [defaults['mpd_host'],
+                   defaults['mpd_port'], defaults['mpd_pass']]
 
     player = Player(player_name, source, autoswitch, mpd_connect, align=align)
     win = Window(stdscr, player, timeout=interval)
@@ -76,8 +77,9 @@ def main():
             print(track.get_text())
 
             exit(0)
-        else:
-            init_pager()
+
+    init_pager()
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fixed `lyrics` command without arguments flow after #35. Now all the following flows should work
- `lyrics`: opens with autoswitch on
- `lyrics {playername}`: opens with autoswitch on and listening to only player `playername`
- `lyrics -t {Artist} {Track Title}`: prints lyrics of provided track in terminal